### PR TITLE
Improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "se.arctosoft.vault"
         minSdk 28
         targetSdk 32
-        versionCode 6
-        versionName "1.2.2"
+        versionCode 7
+        versionName "1.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/se/arctosoft/vault/GalleryActivity.java
+++ b/app/src/main/java/se/arctosoft/vault/GalleryActivity.java
@@ -304,6 +304,12 @@ public class GalleryActivity extends AppCompatActivity {
         if (id == android.R.id.home) {
             onBackPressed();
             return true;
+        } else if (id == R.id.edit_included_folders) {
+            Dialogs.showEditIncludedFolders(this, settings, selectedToRemove -> {
+                settings.removeGalleryDirectories(selectedToRemove);
+                Toaster.getInstance(this).showLong(getResources().getQuantityString(R.plurals.edit_included_removed, selectedToRemove.size(), selectedToRemove.size()));
+                findFolders();
+            });
         } else if (id == R.id.about) {
             Dialogs.showTextDialog(this, getString(R.string.dialog_about_title), getString(R.string.dialog_about_message, BuildConfig.BUILD_TYPE, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE));
         } else if (id == R.id.lock) {

--- a/app/src/main/java/se/arctosoft/vault/GalleryActivity.java
+++ b/app/src/main/java/se/arctosoft/vault/GalleryActivity.java
@@ -134,16 +134,16 @@ public class GalleryActivity extends AppCompatActivity {
 
     private void setLoading(boolean loading) {
         binding.cLLoading.cLLoading.setVisibility(loading ? View.VISIBLE : View.GONE);
-        binding.cLLoading.txtImporting.setVisibility(View.GONE);
+        binding.cLLoading.txtProgress.setVisibility(View.GONE);
     }
 
     private void setLoadingProgress(int progress, int total, String doneMB, String totalMB) {
         binding.cLLoading.cLLoading.setVisibility(View.VISIBLE);
         if (total > 0) {
-            binding.cLLoading.txtImporting.setText(getString(R.string.gallery_importing_progress, progress, total, doneMB, totalMB));
-            binding.cLLoading.txtImporting.setVisibility(View.VISIBLE);
+            binding.cLLoading.txtProgress.setText(getString(R.string.gallery_importing_progress, progress, total, doneMB, totalMB));
+            binding.cLLoading.txtProgress.setVisibility(View.VISIBLE);
         } else {
-            binding.cLLoading.txtImporting.setVisibility(View.GONE);
+            binding.cLLoading.txtProgress.setVisibility(View.GONE);
         }
     }
 

--- a/app/src/main/java/se/arctosoft/vault/GalleryDirectoryActivity.java
+++ b/app/src/main/java/se/arctosoft/vault/GalleryDirectoryActivity.java
@@ -37,7 +37,7 @@ import se.arctosoft.vault.viewmodel.GalleryDirectoryViewModel;
 
 public class GalleryDirectoryActivity extends AppCompatActivity {
     private static final String TAG = "GalleryDirectoryActivity";
-    private static final Object lock = new Object();
+    private static final Object LOCK = new Object();
     public static final String EXTRA_DIRECTORY = "d";
 
     private ActivityGalleryDirectoryBinding binding;
@@ -81,15 +81,16 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
 
     private void setLoading(boolean loading) {
         binding.cLLoading.cLLoading.setVisibility(loading ? View.VISIBLE : View.GONE);
+        binding.cLLoading.txtProgress.setVisibility(View.GONE);
     }
 
-    private void setLoadingProgress(int exported, int failed, int total) {
+    private void setLoadingWithProgress(int progress, int failed, int total, int stringId) {
         binding.cLLoading.cLLoading.setVisibility(View.VISIBLE);
         if (total > 0) {
-            binding.cLLoading.txtImporting.setText(getString(R.string.gallery_exporting_progress, exported, total, failed));
-            binding.cLLoading.txtImporting.setVisibility(View.VISIBLE);
+            binding.cLLoading.txtProgress.setText(getString(stringId, progress, total, failed));
+            binding.cLLoading.txtProgress.setVisibility(View.VISIBLE);
         } else {
-            binding.cLLoading.txtImporting.setVisibility(View.GONE);
+            binding.cLLoading.txtProgress.setVisibility(View.GONE);
         }
     }
 
@@ -111,35 +112,41 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
     private void setClickListeners() {
         binding.btnDeleteFiles.setOnClickListener(v -> Dialogs.showConfirmationDialog(this, getString(R.string.dialog_delete_files_title),
                 getResources().getQuantityString(R.plurals.dialog_delete_files_message, galleryGridAdapter.getSelectedFiles().size()),
-                (dialog, which) -> {
-                    setLoading(true);
-                    new Thread(() -> {
-                        synchronized (lock) {
-                            for (GalleryFile f : galleryGridAdapter.getSelectedFiles()) {
-                                if (isCancelled) {
-                                    isCancelled = false;
-                                    break;
-                                }
-                                boolean deleted = FileStuff.deleteFile(this, f.getUri());
-                                FileStuff.deleteFile(this, f.getThumbUri());
-                                if (deleted) {
-                                    int i = viewModel.getGalleryFiles().indexOf(f);
-                                    if (i >= 0) {
-                                        viewModel.getGalleryFiles().remove(i);
-                                        runOnUiThread(() -> {
-                                            galleryGridAdapter.notifyItemRemoved(i);
-                                            galleryPagerAdapter.notifyItemRemoved(i);
-                                        });
-                                    }
-                                }
-                            }
+                (dialog, which) -> deleteSelectedFiles()));
+    }
+
+    private void deleteSelectedFiles() { // TODO run in parallel to make it faster, ExecutorService
+        setLoading(true);
+        new Thread(() -> {
+            synchronized (LOCK) {
+                int count = 0;
+                int failed = 0;
+                final int total = galleryGridAdapter.getSelectedFiles().size();
+                for (GalleryFile f : galleryGridAdapter.getSelectedFiles()) {
+                    if (isCancelled) {
+                        isCancelled = false;
+                        break;
+                    }
+                    setLoadingWithProgress(++count, failed, total, R.string.gallery_deleting_progress);
+                    boolean deleted = FileStuff.deleteFile(this, f.getUri());
+                    FileStuff.deleteFile(this, f.getThumbUri());
+                    if (deleted) {
+                        int i = viewModel.getGalleryFiles().indexOf(f);
+                        if (i >= 0) {
+                            viewModel.getGalleryFiles().remove(i);
                             runOnUiThread(() -> {
-                                galleryGridAdapter.onSelectionModeChanged(false);
-                                setLoading(false);
+                                galleryGridAdapter.notifyItemRemoved(i);
+                                galleryPagerAdapter.notifyItemRemoved(i);
                             });
                         }
-                    }).start();
-                }));
+                    }
+                }
+                runOnUiThread(() -> {
+                    galleryGridAdapter.onSelectionModeChanged(false);
+                    setLoading(false);
+                });
+            }
+        }).start();
     }
 
     private void setupRecycler() {
@@ -222,7 +229,7 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
 
             runOnUiThread(() -> {
                 setLoading(false);
-                synchronized (lock) {
+                synchronized (LOCK) {
                     if (viewModel.isInitialised()) {
                         return;
                     }
@@ -282,7 +289,7 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
         Dialogs.showConfirmationDialog(this, getString(R.string.dialog_export_selected_title), getString(R.string.dialog_export_selected_message, FileStuff.getFilenameWithPathFromUri(currentDirectory)), (dialog, which) -> {
             isExporting = true;
             final List<GalleryFile> galleryFilesCopy = new ArrayList<>(galleryGridAdapter.getSelectedFiles());
-            setLoadingProgress(0, 0, galleryFilesCopy.size());
+            setLoadingWithProgress(0, 0, galleryFilesCopy.size(), R.string.gallery_exporting_progress);
             galleryGridAdapter.onSelectionModeChanged(false);
             new Thread(() -> {
                 final int[] exported = {0};
@@ -308,7 +315,7 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
                         }
                     };
                     Encryption.decryptAndExport(this, f.getUri(), currentDirectory, settings.getTempPassword(), result, f.isVideo());
-                    runOnUiThread(() -> setLoadingProgress(exported[0], failed[0], galleryFilesCopy.size()));
+                    runOnUiThread(() -> setLoadingWithProgress(exported[0], failed[0], galleryFilesCopy.size(), R.string.gallery_exporting_progress));
                 }
                 runOnUiThread(() -> {
                     isExporting = false;

--- a/app/src/main/java/se/arctosoft/vault/GalleryDirectoryActivity.java
+++ b/app/src/main/java/se/arctosoft/vault/GalleryDirectoryActivity.java
@@ -50,6 +50,7 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
     private Uri currentDirectory;
     private boolean inSelectionMode = false;
     private boolean isExporting = false;
+    private boolean isCancelled = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -117,6 +118,10 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
                     new Thread(() -> {
                         synchronized (lock) {
                             for (GalleryFile f : galleryGridAdapter.getSelectedFiles()) {
+                                if (isCancelled) {
+                                    isCancelled = false;
+                                    break;
+                                }
                                 boolean deleted = FileStuff.deleteFile(this, f.getUri());
                                 FileStuff.deleteFile(this, f.getThumbUri());
                                 if (deleted) {
@@ -309,6 +314,8 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
             showViewpager(false, viewModel.getCurrentPosition(), true);
         } else if (isExporting) {
             isExporting = false;
+        } else if (binding.cLLoading.cLLoading.getVisibility() == View.VISIBLE) {
+            isCancelled = true;
         } else if (inSelectionMode && galleryGridAdapter != null) {
             galleryGridAdapter.onSelectionModeChanged(false);
         } else {

--- a/app/src/main/java/se/arctosoft/vault/adapters/GalleryGridAdapter.java
+++ b/app/src/main/java/se/arctosoft/vault/adapters/GalleryGridAdapter.java
@@ -99,7 +99,7 @@ public class GalleryGridAdapter extends RecyclerView.Adapter<GalleryGridViewHold
         updateSelectedView(holder, galleryFile);
         holder.txtName.setVisibility(showFileNames || galleryFile.isDirectory() ? View.VISIBLE : View.GONE);
         holder.imageView.setImageDrawable(null);
-        if (galleryFile.isGif() || galleryFile.isVideo() || galleryFile.isDirectory()) {
+        if (!isRootDir && (galleryFile.isGif() || galleryFile.isVideo() || galleryFile.isDirectory())) {
             holder.imgType.setVisibility(View.VISIBLE);
             holder.imgType.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), galleryFile.isGif()
                             ? R.drawable.ic_round_gif_24 : (galleryFile.isVideo()

--- a/app/src/main/java/se/arctosoft/vault/adapters/GalleryPagerAdapter.java
+++ b/app/src/main/java/se/arctosoft/vault/adapters/GalleryPagerAdapter.java
@@ -33,7 +33,7 @@ import se.arctosoft.vault.R;
 import se.arctosoft.vault.adapters.viewholders.GalleryPagerViewHolder;
 import se.arctosoft.vault.data.FileType;
 import se.arctosoft.vault.data.GalleryFile;
-import se.arctosoft.vault.encryption.ChaCha20DataSourceFactory;
+import se.arctosoft.vault.encryption.MyDataSourceFactory;
 import se.arctosoft.vault.encryption.Encryption;
 import se.arctosoft.vault.exception.InvalidPasswordException;
 import se.arctosoft.vault.interfaces.IOnFileDeleted;
@@ -131,7 +131,7 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
     private void playVideo(FragmentActivity context, Uri fileUri, GalleryPagerViewHolder.GalleryPagerVideoViewHolder holder) {
         lastPlayerPos = holder.getBindingAdapterPosition();
         if (player == null) {
-            DataSource.Factory dataSourceFactory = new ChaCha20DataSourceFactory(context);
+            DataSource.Factory dataSourceFactory = new MyDataSourceFactory(context);
             ProgressiveMediaSource.Factory progressiveFactory = new ProgressiveMediaSource.Factory(dataSourceFactory);
             player = new ExoPlayer.Builder(context)
                     .setMediaSourceFactory(progressiveFactory)

--- a/app/src/main/java/se/arctosoft/vault/adapters/GalleryPagerAdapter.java
+++ b/app/src/main/java/se/arctosoft/vault/adapters/GalleryPagerAdapter.java
@@ -19,6 +19,7 @@ import com.davemorrissey.labs.subscaleview.ImageSource;
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.ui.StyledPlayerView;
@@ -138,7 +139,7 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
             player.setRepeatMode(Player.REPEAT_MODE_ONE);
         }
         MediaItem mediaItem = new MediaItem.Builder()
-                .setMimeType("video/mp4")
+                .setMimeType("video/*")
                 .setUri(fileUri)
                 .build();
         player.setMediaItem(mediaItem);
@@ -149,6 +150,12 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
             public void onIsPlayingChanged(boolean isPlaying) {
                 Player.Listener.super.onIsPlayingChanged(isPlaying);
                 holder.lLButtons.setVisibility(isPlaying ? View.INVISIBLE : View.VISIBLE);
+            }
+
+            @Override
+            public void onPlayerError(@NonNull PlaybackException error) {
+                Player.Listener.super.onPlayerError(error);
+                Toaster.getInstance(context).showLong(context.getString(R.string.gallery_video_error, error.getMessage()));
             }
         });
         if (playerView != null) {

--- a/app/src/main/java/se/arctosoft/vault/data/CursorFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/CursorFile.java
@@ -9,7 +9,7 @@ public class CursorFile implements Comparable<CursorFile> {
     private final long lastModified, size;
     private final String mimeType;
     private final boolean isDirectory;
-    private String unencryptedName;
+    private String nameWithoutPrefix;
 
     public CursorFile(String name, Uri uri, long lastModified, String mimeType, long size) {
         this.name = name;
@@ -20,16 +20,16 @@ public class CursorFile implements Comparable<CursorFile> {
         this.lastModified = isDirectory ? System.currentTimeMillis() : lastModified;
     }
 
-    public void setUnencryptedName(String unencryptedName) {
-        this.unencryptedName = unencryptedName;
+    public void setNameWithoutPrefix(String nameWithoutPrefix) {
+        this.nameWithoutPrefix = nameWithoutPrefix;
     }
 
     public long getSize() {
         return size;
     }
 
-    public String getUnencryptedName() {
-        return unencryptedName;
+    public String getNameWithoutPrefix() {
+        return nameWithoutPrefix;
     }
 
     public boolean isDirectory() {

--- a/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
@@ -20,6 +20,7 @@ public class GalleryFile implements Comparable<GalleryFile> {
     private final long lastModified, size;
     private Uri thumbUri, decryptedCacheUri;
     private List<GalleryFile> filesInDirectory;
+    private String originalName;
 
     private GalleryFile(@NonNull CursorFile file, @Nullable CursorFile thumb) {
         this.fileUri = file.getUri();
@@ -46,29 +47,21 @@ public class GalleryFile implements Comparable<GalleryFile> {
         this.size = 0;
     }
 
-    private GalleryFile(@NonNull CursorFile file, List<GalleryFile> filesInDirectory) {
-        this.fileUri = file.getUri();
-        this.encryptedName = file.getName();
-        this.name = encryptedName;
-        this.thumbUri = null;
-        this.decryptedCacheUri = null;
-        this.lastModified = System.currentTimeMillis();
-        this.isDirectory = true;
-        this.fileType = FileType.DIRECTORY;
-        this.filesInDirectory = filesInDirectory;
-        this.size = 0;
-    }
-
     public static GalleryFile asDirectory(Uri fileUri, List<GalleryFile> filesInDirectory) {
-        return new GalleryFile(fileUri, filesInDirectory);
-    }
-
-    public static GalleryFile asDirectory(CursorFile fileUri, List<GalleryFile> filesInDirectory) {
         return new GalleryFile(fileUri, filesInDirectory);
     }
 
     public static GalleryFile asFile(CursorFile fileUri, @Nullable CursorFile thumbUri) {
         return new GalleryFile(fileUri, thumbUri);
+    }
+
+    public void setOriginalName(String originalName) {
+        this.originalName = originalName;
+    }
+
+    @Nullable
+    public String getOriginalName() {
+        return originalName;
     }
 
     public void setDecryptedCacheUri(Uri decryptedCacheUri) {
@@ -101,7 +94,7 @@ public class GalleryFile implements Comparable<GalleryFile> {
     }
 
     public String getName() {
-        return name;
+        return (originalName != null && !originalName.isEmpty()) ? originalName : name;
     }
 
     public String getEncryptedName() {

--- a/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
@@ -47,7 +47,24 @@ public class GalleryFile implements Comparable<GalleryFile> {
         this.size = 0;
     }
 
+    private GalleryFile(@NonNull CursorFile file, List<GalleryFile> filesInDirectory) {
+        this.fileUri = file.getUri();
+        this.encryptedName = file.getName();
+        this.name = encryptedName;
+        this.thumbUri = null;
+        this.decryptedCacheUri = null;
+        this.lastModified = System.currentTimeMillis();
+        this.isDirectory = true;
+        this.fileType = FileType.DIRECTORY;
+        this.filesInDirectory = filesInDirectory;
+        this.size = 0;
+    }
+
     public static GalleryFile asDirectory(Uri fileUri, List<GalleryFile> filesInDirectory) {
+        return new GalleryFile(fileUri, filesInDirectory);
+    }
+
+    public static GalleryFile asDirectory(CursorFile fileUri, List<GalleryFile> filesInDirectory) {
         return new GalleryFile(fileUri, filesInDirectory);
     }
 

--- a/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
@@ -140,7 +140,7 @@ public class GalleryFile implements Comparable<GalleryFile> {
             return null;
         }
         for (GalleryFile g : filesInDirectory) {
-            if (!g.isDirectory()) {
+            if (!g.isDirectory() && g.hasThumb()) {
                 return g;
             }
         }

--- a/app/src/main/java/se/arctosoft/vault/data/StoredDirectory.java
+++ b/app/src/main/java/se/arctosoft/vault/data/StoredDirectory.java
@@ -1,0 +1,50 @@
+package se.arctosoft.vault.data;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+
+public class StoredDirectory {
+    private final String uriString;
+    private final Uri uri;
+    private final boolean rootDir;
+
+    public StoredDirectory(String uriString, boolean rootDir) {
+        this.uriString = uriString;
+        this.uri = Uri.parse(uriString);
+        this.rootDir = rootDir;
+    }
+
+    public String getUriString() {
+        return uriString;
+    }
+
+    public Uri getUri() {
+        return uri;
+    }
+
+    public boolean isRootDir() {
+        return rootDir;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StoredDirectory that = (StoredDirectory) o;
+        return uri.equals(that.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return (rootDir ? '1' : '0') + uriString;
+    }
+}

--- a/app/src/main/java/se/arctosoft/vault/encryption/Encryption.java
+++ b/app/src/main/java/se/arctosoft/vault/encryption/Encryption.java
@@ -51,11 +51,11 @@ public class Encryption {
     private static final int IV_LENGTH = 12;
     private static final int CHECK_LENGTH = 12;
 
-    public static final String PREFIX_IMAGE_FILE = ".arcv1.i-";
-    public static final String PREFIX_GIF_FILE = ".arcv1.g-";
-    public static final String ENCRYPTED_PREFIX = ".arcv1.";
-    public static final String PREFIX_VIDEO_FILE = ".arcv1.v-";
-    public static final String PREFIX_THUMB = ".arcv1.t-";
+    public static final String ENCRYPTED_PREFIX = ".valv.";
+    public static final String PREFIX_IMAGE_FILE = ".valv.i.1-";
+    public static final String PREFIX_GIF_FILE = ".valv.g.1-";
+    public static final String PREFIX_VIDEO_FILE = ".valv.v.1-";
+    public static final String PREFIX_THUMB = ".valv.t.1-";
 
     public static Pair<Boolean, Boolean> importFileToDirectory(FragmentActivity context, DocumentFile sourceFile, DocumentFile directory, Settings settings) {
         char[] tempPassword = settings.getTempPassword();
@@ -88,21 +88,6 @@ public class Encryption {
         }
         return new Pair<>(true, createdThumb);
     }
-
-    /*public static void writeFile(FragmentActivity context, Uri input, DocumentFile file, DocumentFile thumb, char[] password, IOnUriResult onUriResult) {
-        new Thread(() -> {
-            try {
-                createFile(context, input, file, password);
-
-                createThumb(context, input, thumb, password);
-
-                context.runOnUiThread(() -> onUriResult.onUriResult(file.getUri()));
-            } catch (GeneralSecurityException | IOException | ExecutionException | InterruptedException e) {
-                e.printStackTrace();
-                context.runOnUiThread(() -> onUriResult.onError(e));
-            }
-        }).start();
-    }*/
 
     public static class Streams {
         private final InputStream inputStream;
@@ -263,7 +248,7 @@ public class Encryption {
         String name = "";
         try {
             Streams streams = getCipherInputStream(inputStream, password, isThumb);
-            name = streams.originalFileName;
+            name = streams.getOriginalFileName();
             streams.close();
         } catch (IOException | GeneralSecurityException | InvalidPasswordException e) {
             e.printStackTrace();

--- a/app/src/main/java/se/arctosoft/vault/encryption/MyDataSource.java
+++ b/app/src/main/java/se/arctosoft/vault/encryption/MyDataSource.java
@@ -20,14 +20,14 @@ import javax.crypto.CipherInputStream;
 import se.arctosoft.vault.exception.InvalidPasswordException;
 import se.arctosoft.vault.utils.Settings;
 
-public class ChaChaDataSource implements DataSource {
-    private static final String TAG = "ChaChaDataSource";
+public class MyDataSource implements DataSource {
+    private static final String TAG = "MyDataSource";
     private final Context context;
 
     private Encryption.Streams streams;
     private Uri uri;
 
-    public ChaChaDataSource(@NonNull Context context) {
+    public MyDataSource(@NonNull Context context) {
         this.context = context.getApplicationContext();
     }
 

--- a/app/src/main/java/se/arctosoft/vault/encryption/MyDataSourceFactory.java
+++ b/app/src/main/java/se/arctosoft/vault/encryption/MyDataSourceFactory.java
@@ -1,22 +1,21 @@
 package se.arctosoft.vault.encryption;
 
 import android.content.Context;
-import android.net.Uri;
 
 import androidx.annotation.NonNull;
 
 import com.google.android.exoplayer2.upstream.DataSource;
 
-public class ChaCha20DataSourceFactory implements DataSource.Factory {
+public class MyDataSourceFactory implements DataSource.Factory {
     private final Context context;
 
-    public ChaCha20DataSourceFactory(Context context) {
+    public MyDataSourceFactory(Context context) {
         this.context = context;
     }
 
     @NonNull
     @Override
     public DataSource createDataSource() {
-        return new ChaChaDataSource(context);
+        return new MyDataSource(context);
     }
 }

--- a/app/src/main/java/se/arctosoft/vault/interfaces/IOnDirectoryAdded.java
+++ b/app/src/main/java/se/arctosoft/vault/interfaces/IOnDirectoryAdded.java
@@ -1,0 +1,13 @@
+package se.arctosoft.vault.interfaces;
+
+import android.net.Uri;
+
+import androidx.annotation.NonNull;
+
+public interface IOnDirectoryAdded {
+    void onAddedAsRoot();
+
+    void onAddedAsChildOf(@NonNull Uri parentUri);
+
+    void onAlreadyExists(boolean isRootDir);
+}

--- a/app/src/main/java/se/arctosoft/vault/loader/CipherDataFetcher.java
+++ b/app/src/main/java/se/arctosoft/vault/loader/CipherDataFetcher.java
@@ -2,7 +2,6 @@ package se.arctosoft.vault.loader;
 
 import android.content.Context;
 import android.net.Uri;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -45,13 +44,11 @@ public class CipherDataFetcher implements DataFetcher<InputStream> {
 
     @Override
     public void cleanup() {
-        Log.i(TAG, "cleanup: ");
         cancel();
     }
 
     @Override
     public void cancel() {
-        Log.i(TAG, "cancel:");
         if (streams != null) {
             streams.close(); // interrupts decode if any
         }

--- a/app/src/main/java/se/arctosoft/vault/utils/Dialogs.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/Dialogs.java
@@ -3,14 +3,13 @@ package se.arctosoft.vault.utils;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.net.Uri;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.documentfile.provider.DocumentFile;
 
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
-import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 import se.arctosoft.vault.R;
@@ -36,6 +35,10 @@ public class Dialogs {
         void onDirectorySelected(@NonNull DocumentFile directory);
     }
 
+    public interface IOnEditedIncludedFolders {
+        void onRemoved(@NonNull List<Uri> selectedToRemove);
+    }
+
     public static void showTextDialog(Context context, String title, String message) {
         new MaterialAlertDialogBuilder(context)
                 .setTitle(title)
@@ -49,6 +52,27 @@ public class Dialogs {
                 .setTitle(title)
                 .setMessage(message)
                 .setPositiveButton(android.R.string.ok, onConfirm)
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    public static void showEditIncludedFolders(Context context, @NonNull Settings settings, @NonNull IOnEditedIncludedFolders onEditedIncludedFolders) {
+        List<Uri> directories = settings.getGalleryDirectoriesAsUri(false);
+        String[] names = new String[directories.size()];
+        for (int i = 0; i < names.length; i++) {
+            names[i] = FileStuff.getFilenameWithPathFromUri(directories.get(i));
+        }
+        List<Uri> selectedToRemove = new LinkedList<>();
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(context.getString(R.string.dialog_edit_included_title))
+                .setMultiChoiceItems(names, null, (dialog, which, isChecked) -> {
+                    if (isChecked) {
+                        selectedToRemove.add(directories.get(which));
+                    } else {
+                        selectedToRemove.remove(directories.get(which));
+                    }
+                })
+                .setPositiveButton(context.getString(R.string.remove), (dialog, which) -> onEditedIncludedFolders.onRemoved(selectedToRemove))
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }

--- a/app/src/main/java/se/arctosoft/vault/utils/Dialogs.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/Dialogs.java
@@ -19,7 +19,7 @@ public class Dialogs {
     private static final String TAG = "Dialogs";
 
     public static void showImportGalleryChooseDestinationDialog(Context context, Settings settings, IOnDirectorySelected onDirectorySelected) {
-        List<Uri> directories = settings.getGalleryDirectoriesAsUri();
+        List<Uri> directories = settings.getGalleryDirectoriesAsUri(false);
         String[] names = new String[directories.size()];
         for (int i = 0; i < names.length; i++) {
             names[i] = FileStuff.getFilenameWithPathFromUri(directories.get(i));

--- a/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
@@ -76,11 +76,11 @@ public class FileStuff {
             //galleryFiles.add(GalleryFile.asDirectory(file, null)); // TODO fix later
             //    continue;
             //}
-            file.setUnencryptedName(FileStuff.getUnencryptedFileName(file.getName()));
+            file.setNameWithoutPrefix(FileStuff.getNameWithoutPrefix(file.getName()));
             boolean foundThumb = false;
             for (CursorFile thumb : documentThumbs) {
-                thumb.setUnencryptedName(FileStuff.getUnencryptedFileName(thumb.getName()));
-                if (file.getUnencryptedName().equals(thumb.getUnencryptedName())) {
+                thumb.setNameWithoutPrefix(FileStuff.getNameWithoutPrefix(thumb.getName()));
+                if (file.getNameWithoutPrefix().equals(thumb.getNameWithoutPrefix())) {
                     galleryFiles.add(GalleryFile.asFile(file, thumb));
                     foundThumb = true;
                     break;
@@ -135,7 +135,7 @@ public class FileStuff {
         return s;
     }
 
-    public static String getUnencryptedFileName(@NonNull String s) {
+    public static String getNameWithoutPrefix(@NonNull String s) {
         return s.split("-", 2)[1];
     }
 

--- a/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
@@ -48,7 +48,6 @@ public class FileStuff {
             long size = c.getLong(4);
             files.add(new CursorFile(name, uri, lastModified, mimeType, size));
         } while (c.moveToNext());
-        //Log.e(TAG, "getFilesInFolder: found " + files.size() + " in " + pickedDir.getLastPathSegment());
         c.close();
         Collections.sort(files);
         return getEncryptedFilesInFolder(files);
@@ -60,7 +59,7 @@ public class FileStuff {
         List<CursorFile> documentThumbs = new ArrayList<>();
         List<GalleryFile> galleryFiles = new ArrayList<>();
         for (CursorFile file : files) {
-            if (!file.getName().startsWith(Encryption.ENCRYPTED_PREFIX) || file.isDirectory()) {
+            if (!file.getName().startsWith(Encryption.ENCRYPTED_PREFIX) && !file.isDirectory()) {
                 continue;
             }
 
@@ -72,10 +71,10 @@ public class FileStuff {
         }
 
         for (CursorFile file : documentFiles) {
-            //if (file.isDirectory()) {
-            //galleryFiles.add(GalleryFile.asDirectory(file, null)); // TODO fix later
-            //    continue;
-            //}
+            if (file.isDirectory()) {
+                galleryFiles.add(GalleryFile.asDirectory(file, null)); // TODO fix later
+                continue;
+            }
             file.setNameWithoutPrefix(FileStuff.getNameWithoutPrefix(file.getName()));
             boolean foundThumb = false;
             for (CursorFile thumb : documentThumbs) {

--- a/app/src/main/java/se/arctosoft/vault/utils/Settings.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/Settings.java
@@ -7,14 +7,15 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.documentfile.provider.DocumentFile;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import se.arctosoft.vault.data.StoredDirectory;
 import se.arctosoft.vault.encryption.Password;
+import se.arctosoft.vault.interfaces.IOnDirectoryAdded;
 
 public class Settings {
     private static final String TAG = "Settings";
@@ -24,7 +25,6 @@ public class Settings {
 
     private final Context context;
     private static Settings settings;
-    // TODO add e.g. "hello" to encrypted file and check it on decrypt. If it does not say "hello" the supplied password is incorrect
 
     private char[] password = null;
 
@@ -83,87 +83,94 @@ public class Settings {
         getSharedPrefsEditor().putString(PREF_PASSWORD_HASH, hash).apply();
     }
 
-    public boolean addGalleryDirectory(@NonNull Uri uri) {
-        List<String> directories = getGalleryDirectories();
+    public void addGalleryDirectory(@NonNull Uri uri, @Nullable IOnDirectoryAdded onDirectoryAdded) {
+        List<StoredDirectory> directories = getGalleryDirectories(false);
+        boolean isRootDir = true;
+        Uri parentFolder = null;
+        for (StoredDirectory storedDirectory : directories) {
+            if (!storedDirectory.isRootDir()) {
+                continue;
+            }
+            if (!uri.equals(storedDirectory.getUri()) && uri.getLastPathSegment().startsWith(storedDirectory.getUri().getLastPathSegment())) { // prevent adding a child of an already added folder
+                isRootDir = false;
+                parentFolder = storedDirectory.getUri();
+                break;
+            }
+        }
         String uriString = uri.toString();
+        StoredDirectory newDir = new StoredDirectory(uriString, isRootDir);
         boolean reordered = false;
-        if (directories.contains(uriString)) {
+        if (directories.contains(newDir)) {
             Log.d(TAG, "addGalleryDirectory: uri already saved");
-            if (directories.remove(uriString)) {
-                directories.add(0, uriString);
+            if (directories.remove(newDir)) {
+                directories.add(0, newDir);
                 reordered = true;
-            } else {
-                return false;
             }
         }
         if (!reordered) {
-            directories.add(0, uriString);
+            directories.add(0, newDir);
         }
         getSharedPrefsEditor().putString(PREF_DIRECTORIES, stringListAsString(directories)).apply();
-        return true;
+        if (onDirectoryAdded != null) {
+            if (reordered) {
+                onDirectoryAdded.onAlreadyExists(isRootDir);
+            } else if (isRootDir) {
+                onDirectoryAdded.onAddedAsRoot();
+            } else {
+                onDirectoryAdded.onAddedAsChildOf(parentFolder);
+            }
+        }
     }
 
     public void removeGalleryDirectory(@NonNull Uri uri) {
-        List<String> directories = getGalleryDirectories();
-        directories.remove(uri.toString());
+        List<StoredDirectory> directories = getGalleryDirectories(false);
+        directories.remove(new StoredDirectory(uri.toString(), false));
         getSharedPrefsEditor().putString(PREF_DIRECTORIES, stringListAsString(directories)).apply();
     }
 
     @NonNull
-    private String stringListAsString(@NonNull List<String> list) {
+    private String stringListAsString(@NonNull List<StoredDirectory> list) {
         if (list.isEmpty()) {
             return "";
         }
         StringBuilder sb = new StringBuilder();
-        Iterator<String> iterator = list.iterator();
+        Iterator<StoredDirectory> iterator = list.iterator();
         while (iterator.hasNext()) {
-            sb.append(iterator.next());
+            sb.append(iterator.next().toString());
             if (iterator.hasNext()) {
                 sb.append("\n");
             }
         }
-        //Log.e(TAG, "stringListAsString: " + sb);
         return sb.toString();
     }
 
     @NonNull
-    public List<Uri> getGalleryDirectoriesAsUri() {
-        List<String> directories = getGalleryDirectories();
-        //Log.e(TAG, "getGalleryDirectoriesAsUri: " + directories.size());
+    public List<Uri> getGalleryDirectoriesAsUri(boolean rootDirsOnly) {
+        List<StoredDirectory> directories = getGalleryDirectories(rootDirsOnly);
         List<Uri> uris = new ArrayList<>(directories.size());
-        for (String s : directories) {
+        for (StoredDirectory s : directories) {
             if (s != null) {
-                uris.add(Uri.parse(s));
+                uris.add(s.getUri());
             }
         }
         return uris;
     }
 
     @NonNull
-    public List<DocumentFile> getGalleryDirectoriesAsDocumentFile(Context context) {
-        List<Uri> uris = getGalleryDirectoriesAsUri();
-        List<DocumentFile> documentFiles = new ArrayList<>(uris.size());
-        for (Uri uri : uris) {
-            DocumentFile pickedDir = DocumentFile.fromTreeUri(context, uri);
-            if (pickedDir != null && pickedDir.isDirectory()) {
-                documentFiles.add(pickedDir);
-            }
-        }
-        return documentFiles;
-    }
-
-    @NonNull
-    private List<String> getGalleryDirectories() {
+    private List<StoredDirectory> getGalleryDirectories(boolean rootDirsOnly) {
         String s = getSharedPrefs().getString(PREF_DIRECTORIES, null);
-        List<String> uris = new ArrayList<>();
+        List<StoredDirectory> storedDirectories = new ArrayList<>();
         if (s != null && !s.isEmpty()) {
             String[] split = s.split("\n");
             for (String value : split) {
                 if (value != null && !value.isEmpty()) {
-                    uris.add(value);
+                    boolean isRootDir = value.charAt(0) == '1';
+                    if (!rootDirsOnly || isRootDir) {
+                        storedDirectories.add(new StoredDirectory(value.substring(1), isRootDir));
+                    }
                 }
             }
         }
-        return uris;
+        return storedDirectories;
     }
 }

--- a/app/src/main/java/se/arctosoft/vault/utils/Settings.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/Settings.java
@@ -128,6 +128,14 @@ public class Settings {
         getSharedPrefsEditor().putString(PREF_DIRECTORIES, stringListAsString(directories)).apply();
     }
 
+    public void removeGalleryDirectories(@NonNull List<Uri> uris) {
+        List<StoredDirectory> directories = getGalleryDirectories(false);
+        for (Uri u : uris) {
+            directories.remove(new StoredDirectory(u.toString(), false));
+        }
+        getSharedPrefsEditor().putString(PREF_DIRECTORIES, stringListAsString(directories)).apply();
+    }
+
     @NonNull
     private String stringListAsString(@NonNull List<StoredDirectory> list) {
         if (list.isEmpty()) {

--- a/app/src/main/java/se/arctosoft/vault/utils/Settings.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/Settings.java
@@ -21,7 +21,6 @@ public class Settings {
     private static final String TAG = "Settings";
     private static final String SHARED_PREFERENCES_NAME = "prefs";
     private static final String PREF_DIRECTORIES = "p.gallery.dirs";
-    private static final String PREF_PASSWORD_HASH = "p.p";
 
     private final Context context;
     private static Settings settings;
@@ -74,15 +73,6 @@ public class Settings {
         }
     }
 
-    @Nullable
-    public String getPasswordHash() {
-        return getSharedPrefs().getString(PREF_PASSWORD_HASH, null);
-    }
-
-    public void setPasswordHash(@Nullable String hash) {
-        getSharedPrefsEditor().putString(PREF_PASSWORD_HASH, hash).apply();
-    }
-
     public void addGalleryDirectory(@NonNull Uri uri, @Nullable IOnDirectoryAdded onDirectoryAdded) {
         List<StoredDirectory> directories = getGalleryDirectories(false);
         boolean isRootDir = true;
@@ -106,8 +96,7 @@ public class Settings {
                 directories.add(0, newDir);
                 reordered = true;
             }
-        }
-        if (!reordered) {
+        } else {
             directories.add(0, newDir);
         }
         getSharedPrefsEditor().putString(PREF_DIRECTORIES, stringListAsString(directories)).apply();

--- a/app/src/main/java/se/arctosoft/vault/utils/StringStuff.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/StringStuff.java
@@ -2,7 +2,27 @@ package se.arctosoft.vault.utils;
 
 import android.icu.text.DecimalFormat;
 
+import androidx.annotation.NonNull;
+
+import java.util.Random;
+
 public class StringStuff {
+    private static final String ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_";
+    private static final int NAME_LENGTH = 32;
+
+    public static String getRandomFileName() {
+        return getRandomFileName(NAME_LENGTH);
+    }
+
+    @NonNull
+    public static String getRandomFileName(int length) {
+        final Random random = new Random();
+        final StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; ++i) {
+            sb.append(ALLOWED_CHARACTERS.charAt(random.nextInt(ALLOWED_CHARACTERS.length())));
+        }
+        return sb.toString();
+    }
 
     public static String bytesToReadableString(long bytes) {
         final DecimalFormat decimalFormat = new DecimalFormat("0.00");

--- a/app/src/main/res/drawable/ic_outline_video_file_24.xml
+++ b/app/src/main/res/drawable/ic_outline_video_file_24.xml
@@ -1,5 +1,5 @@
-<vector android:height="24dp" android:tint="#000000"
+<vector android:height="24dp" android:tint="?toolbar_icon_tint"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M14,2H6C4.9,2 4,2.9 4,4v16c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V8L14,2zM6,20V4h7v5h5v11H6zM14,14l2,-1.06v4.12L14,16v1c0,0.55 -0.45,1 -1,1H9c-0.55,0 -1,-0.45 -1,-1v-4c0,-0.55 0.45,-1 1,-1h4c0.55,0 1,0.45 1,1V14z"/>
+    <path android:fillColor="?toolbar_icon_tint" android:pathData="M14,2H6C4.9,2 4,2.9 4,4v16c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V8L14,2zM6,20V4h7v5h5v11H6zM14,14l2,-1.06v4.12L14,16v1c0,0.55 -0.45,1 -1,1H9c-0.55,0 -1,-0.45 -1,-1v-4c0,-0.55 0.45,-1 1,-1h4c0.55,0 1,0.45 1,1V14z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_round_folder_open_24.xml
+++ b/app/src/main/res/drawable/ic_round_folder_open_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="?toolbar_icon_tint"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="?toolbar_icon_tint" android:pathData="M20,6h-8l-1.41,-1.41C10.21,4.21 9.7,4 9.17,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,8c0,-1.1 -0.9,-2 -2,-2zM19,18L5,18c-0.55,0 -1,-0.45 -1,-1L4,9c0,-0.55 0.45,-1 1,-1h14c0.55,0 1,0.45 1,1v8c0,0.55 -0.45,1 -1,1z"/>
+</vector>

--- a/app/src/main/res/layout/adapter_gallery_grid_item.xml
+++ b/app/src/main/res/layout/adapter_gallery_grid_item.xml
@@ -31,6 +31,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:layout_marginEnd="4dp"
+                android:autoSizeMaxTextSize="12sp"
+                android:autoSizeMinTextSize="9sp"
+                android:autoSizeTextType="uniform"
+                android:maxLines="4"
                 android:textSize="12sp" />
 
         </LinearLayout>

--- a/app/src/main/res/layout/loading_item.xml
+++ b/app/src/main/res/layout/loading_item.xml
@@ -37,7 +37,7 @@
         app:layout_constraintTop_toBottomOf="@id/progressBar" />
 
     <TextView
-        android:id="@+id/txtImporting"
+        android:id="@+id/txt_progress"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"

--- a/app/src/main/res/menu/menu_gallery.xml
+++ b/app/src/main/res/menu/menu_gallery.xml
@@ -11,10 +11,6 @@
         android:title="@string/menu_gallery_edit_included_folders"
         app:showAsAction="never" />-->
     <item
-        android:id="@+id/import_files"
-        android:title="@string/menu_gallery_import"
-        app:showAsAction="never" />
-    <item
         android:id="@+id/about"
         android:title="@string/menu_about"
         app:showAsAction="never" />

--- a/app/src/main/res/menu/menu_gallery.xml
+++ b/app/src/main/res/menu/menu_gallery.xml
@@ -6,10 +6,10 @@
         android:icon="@drawable/ic_outline_lock_24"
         android:title="@string/menu_lock_vault"
         app:showAsAction="ifRoom" />
-    <!--<item
+    <item
         android:id="@+id/edit_included_folders"
         android:title="@string/menu_gallery_edit_included_folders"
-        app:showAsAction="never" />-->
+        app:showAsAction="never" />
     <item
         android:id="@+id/about"
         android:title="@string/menu_about"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,9 @@
     <string name="gallery_importing_progress">Importing %1$d out of %2$d\n%3$s/%4$s MB</string>
     <string name="gallery_exporting_progress">Exporting %1$d out of %2$d\nFailed: %3$d</string>
     <string name="gallery_importing_error">Failed to import %1$s</string>
+    <string name="gallery_importing_error_no_thumb">Failed to create thumb for %1$s</string>
     <string name="gallery_importing_done">Encrypted and imported %1$d files</string>
+    <string name="gallery_video_error">Playback error: %1$s</string>
 
     <string name="dialog_remove_folder_title">Remove?</string>
     <plurals name="dialog_remove_folder_message">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="gallery_file_not_exported">Export error: %1$s</string>
     <string name="gallery_importing_progress">Importing %1$d out of %2$d\n%3$s/%4$s MB</string>
     <string name="gallery_exporting_progress">Exporting %1$d out of %2$d\nFailed: %3$d</string>
+    <string name="gallery_deleting_progress">Deleting %1$d out of %2$d\nFailed: %3$d</string>
     <string name="gallery_importing_error">Failed to import %1$s</string>
     <string name="gallery_importing_error_no_thumb">Failed to create thumb for %1$s</string>
     <string name="gallery_importing_done">Encrypted and imported %1$d files</string>
@@ -54,8 +55,8 @@
 
     <string name="dialog_remove_folder_title">Remove?</string>
     <plurals name="dialog_remove_folder_message">
-        <item quantity="one">Remove the selected folder from your vault? The contained files will not be deleted</item>
-        <item quantity="other">Remove the selected folders from your vault? The contained files will not be deleted</item>
+        <item quantity="one">Remove the selected folder from your vault? The folder on disk and contained files will not be deleted</item>
+        <item quantity="other">Remove the selected folders from your vault? The folder on disk and contained files will not be deleted</item>
     </plurals>
     <string name="dialog_delete_files_title">Delete?</string>
     <plurals name="dialog_delete_files_message">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="help">Help</string>
     <string name="delete">Delete</string>
     <string name="export">Export</string>
+    <string name="remove">Remove</string>
 
     <string name="launcher_title">Vault locked</string>
     <string name="launcher_subtitle">Enter decryption password</string>
@@ -62,6 +63,11 @@
         <item quantity="other">Delete the selected files permanently? This action is irreversible</item>
     </plurals>
     <string name="dialog_import_to_title">Destination</string>
+    <string name="dialog_edit_included_title">Select folders to remove</string>
+    <plurals name="edit_included_removed">
+        <item quantity="one">Removed %1$d folder</item>
+        <item quantity="other">Removed %1$d folders</item>
+    </plurals>
     <string name="dialog_export_title">Export?</string>
     <string name="dialog_export_message">Decrypt and export this file?</string>
     <string name="dialog_export_selected_title">Export?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,9 @@
     <string name="gallery_adapter_folder_name">%1$s (%2$d)</string>
     <string name="gallery_adapter_file_name">%1$s (%2$s)</string>
     <string name="gallery_add_folder">Add a folder</string>
+    <string name="gallery_added_folder">Added %1$s</string>
+    <string name="gallery_added_folder_duplicate">You have already added %1$s</string>
+    <string name="gallery_added_folder_child">Added %1$s as a child of %2$s</string>
     <string name="gallery_import_files">Import files</string>
     <string name="gallery_import_images">Images/GIFs</string>
     <string name="gallery_import_videos">Videos</string>


### PR DESCRIPTION
- Show an error message when video playback fails
- The grid now shows the first file with a thumbnail for a directory and not just the first file
- An error message is now displayed when the thumbnail creation fails instead of throwing away the entire file
- Cancel file deletion with back press
- Encrypt original filename
- Encrypted files now have random names
- Pause and destroy the video player on orientation change. Also pause it on activity stop
- Show subdirectories in the grid
- Menu item to remove added folders
- Show progress when deleting files
- Changed encryption prefix