### PR TITLE
Version 1.3.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,14 +3,14 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "se.arctosoft.vault"
         minSdk 28
-        targetSdk 32
-        versionCode 8
-        versionName "1.3.1"
+        targetSdk 33
+        versionCode 9
+        versionName "1.3.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -38,6 +38,7 @@ android {
     buildFeatures {
         viewBinding true
     }
+    namespace 'se.arctosoft.vault'
 }
 
 dependencies {
@@ -47,7 +48,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.security:security-crypto:1.0.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="se.arctosoft.vault">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/se/arctosoft/vault/GalleryActivity.java
+++ b/app/src/main/java/se/arctosoft/vault/GalleryActivity.java
@@ -17,6 +17,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.documentfile.provider.DocumentFile;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -33,6 +34,7 @@ import se.arctosoft.vault.utils.Dialogs;
 import se.arctosoft.vault.utils.FileStuff;
 import se.arctosoft.vault.utils.Settings;
 import se.arctosoft.vault.utils.Toaster;
+import se.arctosoft.vault.viewmodel.GalleryViewModel;
 
 public class GalleryActivity extends AppCompatActivity {
     private static final String TAG = "GalleryActivity";
@@ -42,6 +44,7 @@ public class GalleryActivity extends AppCompatActivity {
 
     private static final Object lock = new Object();
 
+    private GalleryViewModel viewModel;
     private ActivityGalleryBinding binding;
     private GalleryGridAdapter galleryGridAdapter;
     private List<GalleryFile> galleryFiles;
@@ -66,6 +69,7 @@ public class GalleryActivity extends AppCompatActivity {
     }
 
     private void init() {
+        viewModel = new ViewModelProvider(this).get(GalleryViewModel.class);
         settings = Settings.getInstance(this);
         if (settings.isLocked()) {
             finish();
@@ -176,32 +180,38 @@ public class GalleryActivity extends AppCompatActivity {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == REQUEST_ADD_DIRECTORY && resultCode == Activity.RESULT_OK) {
-            if (data != null) {
-                Uri uri = data.getData();
-                DocumentFile documentFile = DocumentFile.fromTreeUri(this, uri);
-                getContentResolver().takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                settings.addGalleryDirectory(documentFile.getUri(), new IOnDirectoryAdded() {
-                    @Override
-                    public void onAddedAsRoot() {
-                        Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_added_folder, FileStuff.getFilenameWithPathFromUri(uri)));
-                        addDirectory(documentFile.getUri());
-                    }
-
-                    @Override
-                    public void onAddedAsChildOf(@NonNull Uri parentUri) {
-                        Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_added_folder_child, FileStuff.getFilenameWithPathFromUri(uri), FileStuff.getFilenameWithPathFromUri(parentUri)));
-                    }
-
-                    @Override
-                    public void onAlreadyExists(boolean isRootDir) {
-                        Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_added_folder_duplicate, FileStuff.getFilenameWithPathFromUri(uri)));
-                        if (isRootDir) {
-                            findFolders();
+        if (requestCode == REQUEST_ADD_DIRECTORY) {
+            if (resultCode == Activity.RESULT_OK) {
+                if (data != null) {
+                    Uri uri = data.getData();
+                    DocumentFile documentFile = DocumentFile.fromTreeUri(this, uri);
+                    getContentResolver().takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                    settings.addGalleryDirectory(documentFile.getUri(), new IOnDirectoryAdded() {
+                        @Override
+                        public void onAddedAsRoot() {
+                            Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_added_folder, FileStuff.getFilenameWithPathFromUri(uri)));
+                            addDirectory(documentFile.getUri());
                         }
-                    }
-                });
 
+                        @Override
+                        public void onAddedAsChildOf(@NonNull Uri parentUri) {
+                            Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_added_folder_child, FileStuff.getFilenameWithPathFromUri(uri), FileStuff.getFilenameWithPathFromUri(parentUri)));
+                        }
+
+                        @Override
+                        public void onAlreadyExists(boolean isRootDir) {
+                            Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_added_folder_duplicate, FileStuff.getFilenameWithPathFromUri(uri)));
+                            if (isRootDir) {
+                                findFolders();
+                            }
+                        }
+                    });
+                    if (viewModel.getFilesToAdd() != null) {
+                        importFiles(viewModel.getFilesToAdd());
+                    }
+                }
+            } else if (resultCode == Activity.RESULT_CANCELED) {
+                viewModel.setFilesToAdd(null);
             }
         } else if ((requestCode == REQUEST_IMPORT_IMAGES || requestCode == REQUEST_IMPORT_VIDEOS) && resultCode == Activity.RESULT_OK) {
             if (data != null) {
@@ -214,60 +224,74 @@ public class GalleryActivity extends AppCompatActivity {
     }
 
     private void importFiles(List<DocumentFile> documentFiles) {
-        Dialogs.showImportGalleryChooseDestinationDialog(this, settings, directory -> {
+        Dialogs.showImportGalleryChooseDestinationDialog(this, settings, new Dialogs.IOnDirectorySelected() {
+            @Override
+            public void onDirectorySelected(@NonNull DocumentFile directory) {
+                importToDirectory(documentFiles, directory);
+            }
+
+            @Override
+            public void onOtherDirectory() {
+                viewModel.setFilesToAdd(documentFiles);
+                binding.btnAddFolder.performClick();
+            }
+        });
+    }
+
+    private void importToDirectory(@NonNull List<DocumentFile> documentFiles, @NonNull DocumentFile directory) {
+        new Thread(() -> {
             double totalSize = 0;
             for (DocumentFile file : documentFiles) {
                 totalSize += (file.length() / 1000000.0);
             }
             final DecimalFormat decimalFormat = new DecimalFormat("0.00");
             final String totalMB = decimalFormat.format(totalSize);
-            new Thread(() -> {
-                final int[] progress = new int[]{1};
-                final double[] bytesDone = new double[]{0};
-                runOnUiThread(() -> setLoadingProgress(progress[0], documentFiles.size(), "0", totalMB));
-                for (DocumentFile file : documentFiles) {
-                    if (cancelTask) {
+            final int[] progress = new int[]{1};
+            final double[] bytesDone = new double[]{0};
+            runOnUiThread(() -> setLoadingProgress(progress[0], documentFiles.size(), "0", totalMB));
+            for (DocumentFile file : documentFiles) {
+                if (cancelTask) {
+                    cancelTask = false;
+                    break;
+                }
+                Pair<Boolean, Boolean> imported = new Pair<>(false, false);
+                try {
+                    imported = Encryption.importFileToDirectory(GalleryActivity.this, file, directory, settings);
+                } catch (SecurityException e) {
+                    e.printStackTrace();
+                }
+                progress[0]++;
+                bytesDone[0] += file.length();
+                runOnUiThread(() -> setLoadingProgress(progress[0], documentFiles.size(), decimalFormat.format(bytesDone[0] / 1000000.0), totalMB));
+                if (!imported.first) {
+                    runOnUiThread(() -> Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_importing_error, file.getName())));
+                } else if (!imported.second) {
+                    runOnUiThread(() -> Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_importing_error_no_thumb, file.getName())));
+                }
+            }
+            runOnUiThread(() -> {
+                Toaster.getInstance(GalleryActivity.this).showLong(getString(R.string.gallery_importing_done, progress[0] - 1));
+                setLoading(false);
+            });
+            settings.addGalleryDirectory(directory.getUri(), null);
+            synchronized (lock) {
+                for (int i = 0; i < GalleryActivity.this.galleryFiles.size(); i++) {
+                    GalleryFile g = GalleryActivity.this.galleryFiles.get(i);
+                    if (g.getUri().equals(directory.getUri())) {
+                        List<GalleryFile> galleryFiles = FileStuff.getFilesInFolder(GalleryActivity.this, directory.getUri());
+                        g.setFilesInDirectory(galleryFiles);
+                        int finalI = i;
+                        GalleryFile removed = GalleryActivity.this.galleryFiles.remove(finalI);
+                        GalleryActivity.this.galleryFiles.add(0, removed);
+                        runOnUiThread(() -> {
+                            galleryGridAdapter.notifyItemMoved(finalI, 0);
+                            galleryGridAdapter.notifyItemChanged(0);
+                        });
                         break;
                     }
-                    Pair<Boolean, Boolean> imported = new Pair<>(false, false);
-                    try {
-                        imported = Encryption.importFileToDirectory(this, file, directory, settings);
-                    } catch (SecurityException e) {
-                        e.printStackTrace();
-                    }
-                    progress[0]++;
-                    bytesDone[0] += file.length();
-                    runOnUiThread(() -> setLoadingProgress(progress[0], documentFiles.size(), decimalFormat.format(bytesDone[0] / 1000000.0), totalMB));
-                    if (!imported.first) {
-                        runOnUiThread(() -> Toaster.getInstance(this).showLong(getString(R.string.gallery_importing_error, file.getName())));
-                    } else if (!imported.second) {
-                        runOnUiThread(() -> Toaster.getInstance(this).showLong(getString(R.string.gallery_importing_error_no_thumb, file.getName())));
-                    }
                 }
-                runOnUiThread(() -> {
-                    Toaster.getInstance(this).showLong(getString(R.string.gallery_importing_done, progress[0] - 1));
-                    setLoading(false);
-                });
-                synchronized (lock) {
-                    for (int i = 0; i < this.galleryFiles.size(); i++) {
-                        GalleryFile g = this.galleryFiles.get(i);
-                        if (g.getUri().equals(directory.getUri())) {
-                            List<GalleryFile> galleryFiles = FileStuff.getFilesInFolder(this, directory.getUri());
-                            g.setFilesInDirectory(galleryFiles);
-                            int finalI = i;
-                            settings.addGalleryDirectory(g.getUri(), null);
-                            GalleryFile removed = this.galleryFiles.remove(finalI);
-                            this.galleryFiles.add(0, removed);
-                            runOnUiThread(() -> {
-                                galleryGridAdapter.notifyItemMoved(finalI, 0);
-                                galleryGridAdapter.notifyItemChanged(0);
-                            });
-                            break;
-                        }
-                    }
-                }
-            }).start();
-        });
+            }
+        }).start();
     }
 
     private void addDirectory(Uri directoryUri) {

--- a/app/src/main/java/se/arctosoft/vault/GalleryDirectoryActivity.java
+++ b/app/src/main/java/se/arctosoft/vault/GalleryDirectoryActivity.java
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 import androidx.viewpager2.widget.ViewPager2;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import se.arctosoft.vault.adapters.GalleryGridAdapter;
@@ -122,6 +123,7 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
                 final int[] count = {0};
                 int failed = 0;
                 final int total = galleryGridAdapter.getSelectedFiles().size();
+                final List<Integer> positionsDeleted = new ArrayList<>();
                 for (GalleryFile f : galleryGridAdapter.getSelectedFiles()) {
                     if (isCancelled) {
                         isCancelled = false;
@@ -133,15 +135,17 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
                     if (deleted) {
                         int i = viewModel.getGalleryFiles().indexOf(f);
                         if (i >= 0) {
-                            viewModel.getGalleryFiles().remove(i);
-                            runOnUiThread(() -> {
-                                galleryGridAdapter.notifyItemRemoved(i);
-                                galleryPagerAdapter.notifyItemRemoved(i);
-                            });
+                            positionsDeleted.add(i);
                         }
                     }
                 }
                 runOnUiThread(() -> {
+                    Collections.sort(positionsDeleted);
+                    for (int i = positionsDeleted.size() - 1; i >= 0; i--) {
+                        viewModel.getGalleryFiles().remove(i);
+                        galleryGridAdapter.notifyItemRemoved(i);
+                        galleryPagerAdapter.notifyItemRemoved(i);
+                    }
                     galleryGridAdapter.onSelectionModeChanged(false);
                     setLoading(false);
                 });
@@ -216,16 +220,6 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
         setLoading(true);
         new Thread(() -> {
             List<GalleryFile> galleryFiles = FileStuff.getFilesInFolder(this, directoryUri);
-            for (int i = 0; i < galleryFiles.size(); i++) {
-                GalleryFile g = galleryFiles.get(i);
-                if (g.isDirectory()) {
-                    int finalI = i;
-                    new Thread(() -> {
-                        g.setFilesInDirectory(FileStuff.getFilesInFolder(this, g.getUri()));
-                        runOnUiThread(() -> galleryGridAdapter.notifyItemChanged(finalI));
-                    }).start();
-                }
-            }
 
             runOnUiThread(() -> {
                 setLoading(false);
@@ -238,6 +232,17 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
                     galleryPagerAdapter.notifyItemRangeInserted(0, galleryFiles.size());
                 }
             });
+
+            for (int i = 0; i < galleryFiles.size(); i++) {
+                GalleryFile g = galleryFiles.get(i);
+                if (g.isDirectory()) {
+                    int finalI = i;
+                    new Thread(() -> {
+                        g.setFilesInDirectory(FileStuff.getFilesInFolder(this, g.getUri()));
+                        runOnUiThread(() -> galleryGridAdapter.notifyItemChanged(finalI));
+                    }).start();
+                }
+            }
         }).start();
     }
 

--- a/app/src/main/java/se/arctosoft/vault/data/CursorFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/CursorFile.java
@@ -17,7 +17,7 @@ public class CursorFile implements Comparable<CursorFile> {
         this.mimeType = mimeType;
         this.size = size;
         this.isDirectory = DocumentsContract.Document.MIME_TYPE_DIR.equals(mimeType);
-        this.lastModified = isDirectory ? System.currentTimeMillis() : lastModified;
+        this.lastModified = lastModified;
     }
 
     public void setNameWithoutPrefix(String nameWithoutPrefix) {

--- a/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
@@ -53,23 +53,23 @@ public class GalleryFile implements Comparable<GalleryFile> {
         this.name = encryptedName;
         this.thumbUri = null;
         this.decryptedCacheUri = null;
-        this.lastModified = System.currentTimeMillis();
+        this.lastModified = file.getLastModified();
         this.isDirectory = true;
         this.fileType = FileType.DIRECTORY;
         this.filesInDirectory = filesInDirectory;
         this.size = 0;
     }
 
-    public static GalleryFile asDirectory(Uri fileUri, List<GalleryFile> filesInDirectory) {
-        return new GalleryFile(fileUri, filesInDirectory);
+    public static GalleryFile asDirectory(Uri directoryUri, List<GalleryFile> filesInDirectory) {
+        return new GalleryFile(directoryUri, filesInDirectory);
     }
 
-    public static GalleryFile asDirectory(CursorFile fileUri, List<GalleryFile> filesInDirectory) {
-        return new GalleryFile(fileUri, filesInDirectory);
+    public static GalleryFile asDirectory(CursorFile cursorFile, List<GalleryFile> filesInDirectory) {
+        return new GalleryFile(cursorFile, filesInDirectory);
     }
 
-    public static GalleryFile asFile(CursorFile fileUri, @Nullable CursorFile thumbUri) {
-        return new GalleryFile(fileUri, thumbUri);
+    public static GalleryFile asFile(CursorFile cursorFile, @Nullable CursorFile thumbUri) {
+        return new GalleryFile(cursorFile, thumbUri);
     }
 
     public void setOriginalName(String originalName) {
@@ -137,6 +137,10 @@ public class GalleryFile implements Comparable<GalleryFile> {
 
     public boolean isDirectory() {
         return isDirectory;
+    }
+
+    public long getLastModified() {
+        return lastModified;
     }
 
     @Nullable

--- a/app/src/main/java/se/arctosoft/vault/utils/Dialogs.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/Dialogs.java
@@ -28,11 +28,14 @@ public class Dialogs {
                 .setTitle(context.getString(R.string.dialog_import_to_title))
                 .setItems(names, (dialog, which) -> onDirectorySelected.onDirectorySelected(DocumentFile.fromTreeUri(context, directories.get(which))))
                 .setNegativeButton(android.R.string.cancel, null)
+                .setNeutralButton(R.string.dialog_import_to_button_neutral, (dialog, which) -> onDirectorySelected.onOtherDirectory())
                 .show();
     }
 
     public interface IOnDirectorySelected {
         void onDirectorySelected(@NonNull DocumentFile directory);
+
+        void onOtherDirectory();
     }
 
     public interface IOnEditedIncludedFolders {

--- a/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
@@ -50,7 +50,9 @@ public class FileStuff {
         } while (c.moveToNext());
         c.close();
         Collections.sort(files);
-        return getEncryptedFilesInFolder(files);
+        List<GalleryFile> encryptedFilesInFolder = getEncryptedFilesInFolder(files);
+        Collections.sort(encryptedFilesInFolder);
+        return encryptedFilesInFolder;
     }
 
     @NonNull

--- a/app/src/main/java/se/arctosoft/vault/viewmodel/GalleryViewModel.java
+++ b/app/src/main/java/se/arctosoft/vault/viewmodel/GalleryViewModel.java
@@ -1,0 +1,20 @@
+package se.arctosoft.vault.viewmodel;
+
+import androidx.annotation.Nullable;
+import androidx.documentfile.provider.DocumentFile;
+import androidx.lifecycle.ViewModel;
+
+import java.util.List;
+
+public class GalleryViewModel extends ViewModel {
+    private List<DocumentFile> filesToAdd;
+
+    public void setFilesToAdd(@Nullable List<DocumentFile> filesToAdd) {
+        this.filesToAdd = filesToAdd;
+    }
+
+    @Nullable
+    public List<DocumentFile> getFilesToAdd() {
+        return filesToAdd;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
         <item quantity="other">Delete the selected files permanently? This action is irreversible</item>
     </plurals>
     <string name="dialog_import_to_title">Destination</string>
+    <string name="dialog_import_to_button_neutral">Add new</string>
     <string name="dialog_edit_included_title">Select folders to remove</string>
     <plurals name="edit_included_removed">
         <item quantity="one">Removed %1$d folder</item>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.2' apply false
-    id 'com.android.library' version '7.2.2' apply false
+    id 'com.android.application' version '7.3.0' apply false
+    id 'com.android.library' version '7.3.0' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jul 15 12:55:35 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Fixed a bug where cancelling the file import prevented importing more files unless the app was restarted/locked
- Fixed a crash when deleting files
- Use last modified date for folders instead of current millis, folders are now ordered by most recently updated first
- Added a dialog button to choose a new destination when importing files