### PR TITLE
Version 1.7.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "se.arctosoft.vault"
         minSdk 28
         targetSdk 34
-        versionCode 22
-        versionName "1.6.1"
+        versionCode 23
+        versionName "1.7.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "se.arctosoft.vault"
         minSdk 28
         targetSdk 34
-        versionCode 21
+        versionCode 22
         versionName "1.6.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/se/arctosoft/vault/adapters/GalleryGridAdapter.java
+++ b/app/src/main/java/se/arctosoft/vault/adapters/GalleryGridAdapter.java
@@ -29,7 +29,6 @@ import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.cardview.widget.CardView;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.FragmentActivity;
@@ -120,7 +119,6 @@ public class GalleryGridAdapter extends RecyclerView.Adapter<GalleryGridViewHold
     @Override
     public GalleryGridViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         AdapterGalleryGridItemBinding binding = AdapterGalleryGridItemBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
-        CardView v = (CardView) LayoutInflater.from(parent.getContext()).inflate(R.layout.adapter_gallery_grid_item, parent, false);
         return new GalleryGridViewHolder(binding);
     }
 

--- a/app/src/main/java/se/arctosoft/vault/adapters/GalleryPagerAdapter.java
+++ b/app/src/main/java/se/arctosoft/vault/adapters/GalleryPagerAdapter.java
@@ -72,6 +72,7 @@ import se.arctosoft.vault.interfaces.IOnFileDeleted;
 import se.arctosoft.vault.utils.Dialogs;
 import se.arctosoft.vault.utils.FileStuff;
 import se.arctosoft.vault.utils.Settings;
+import se.arctosoft.vault.utils.StringStuff;
 import se.arctosoft.vault.utils.Toaster;
 
 public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHolder> {
@@ -120,15 +121,20 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
         FragmentActivity context = weakReference.get();
         GalleryFile galleryFile = galleryFiles.get(position);
 
-        holder.parentBinding.txtName.setText(galleryFile.getName());
+        setName(holder, galleryFile);
         if (holder instanceof GalleryPagerViewHolder.GalleryPagerVideoViewHolder) {
             setupVideoView((GalleryPagerViewHolder.GalleryPagerVideoViewHolder) holder, context, galleryFile);
         } else {
+            holder.parentBinding.imgFullscreen.setVisibility(View.GONE);
             setupImageView(holder, context, galleryFile);
         }
         setupButtons(holder, context, galleryFile);
         loadOriginalFilename(galleryFile, context, holder, position);
         loadNote(holder, context, galleryFile);
+    }
+
+    private void setName(@NonNull GalleryPagerViewHolder holder, GalleryFile galleryFile) {
+        holder.parentBinding.txtName.setText(weakReference.get().getString(R.string.gallery_adapter_file_name, galleryFile.getName(), StringStuff.bytesToReadableString(galleryFile.getSize())));
     }
 
     @Override
@@ -142,7 +148,7 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
                     break;
                 } else if (o instanceof GalleryGridAdapter.Payload p) {
                     if (p.type() == GalleryGridAdapter.Payload.TYPE_NEW_FILENAME) {
-                        holder.parentBinding.txtName.setText(galleryFiles.get(position).getName());
+                        setName(holder, galleryFiles.get(position));
                         found = true;
                     } else if (p.type() == GalleryGridAdapter.Payload.TYPE_LOADED_NOTE) {
                         loadNote(holder, weakReference.get(), galleryFiles.get(position));
@@ -167,7 +173,7 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
                     galleryFile.setOriginalName(originalFilename);
                     int pos = holder.getBindingAdapterPosition();
                     if (pos == position) {
-                        context.runOnUiThread(() -> holder.parentBinding.txtName.setText(galleryFile.getName()));
+                        context.runOnUiThread(() -> setName(holder, galleryFile));
                     } else if (pos >= 0 && pos < galleryFiles.size()) {
                         context.runOnUiThread(() -> notifyItemChanged(pos, new GalleryGridAdapter.Payload(GalleryGridAdapter.Payload.TYPE_NEW_FILENAME)));
                     }
@@ -185,8 +191,8 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
         Glide.with(context)
                 .load(galleryFile.getThumbUri())
                 .into(holder.binding.imgThumb);
-        holder.binding.imgFullscreen.setOnClickListener(v -> toggleFullscreen(weakReference.get()));
-        holder.binding.imgFullscreen.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
+        holder.parentBinding.imgFullscreen.setOnClickListener(v -> toggleFullscreen(weakReference.get()));
+        holder.parentBinding.imgFullscreen.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
         holder.binding.rLPlay.setOnClickListener(v -> {
             holder.binding.rLPlay.setVisibility(View.GONE);
             holder.binding.playerView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/se/arctosoft/vault/adapters/ImportListAdapter.java
+++ b/app/src/main/java/se/arctosoft/vault/adapters/ImportListAdapter.java
@@ -1,0 +1,59 @@
+/*
+ * Valv-Android
+ * Copyright (C) 2023 Arctosoft AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+package se.arctosoft.vault.adapters;
+
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.List;
+
+import se.arctosoft.vault.adapters.viewholders.ImportListViewHolder;
+import se.arctosoft.vault.databinding.AdapterImportListItemBinding;
+import se.arctosoft.vault.utils.Dialogs;
+
+public class ImportListAdapter extends RecyclerView.Adapter<ImportListViewHolder> {
+    private final List<String> names;
+    private final Dialogs.IOnPositionSelected onPositionSelected;
+
+    public ImportListAdapter(List<String> names, Dialogs.IOnPositionSelected onPositionSelected) {
+        this.names = names;
+        this.onPositionSelected = onPositionSelected;
+    }
+
+    @NonNull
+    @Override
+    public ImportListViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        AdapterImportListItemBinding binding = AdapterImportListItemBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
+        return new ImportListViewHolder(binding);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ImportListViewHolder holder, int position) {
+        holder.binding.text.setText(names.get(position));
+        holder.binding.text.setOnClickListener(v -> onPositionSelected.onSelected(position));
+    }
+
+    @Override
+    public int getItemCount() {
+        return names.size();
+    }
+}

--- a/app/src/main/java/se/arctosoft/vault/adapters/viewholders/ImportListViewHolder.java
+++ b/app/src/main/java/se/arctosoft/vault/adapters/viewholders/ImportListViewHolder.java
@@ -1,0 +1,33 @@
+/*
+ * Valv-Android
+ * Copyright (C) 2023 Arctosoft AB
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+package se.arctosoft.vault.adapters.viewholders;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import se.arctosoft.vault.databinding.AdapterImportListItemBinding;
+
+public class ImportListViewHolder extends RecyclerView.ViewHolder {
+    public final AdapterImportListItemBinding binding;
+
+    public ImportListViewHolder(@NonNull AdapterImportListItemBinding binding) {
+        super(binding.getRoot());
+        this.binding = binding;
+    }
+}

--- a/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
@@ -63,7 +63,7 @@ public class GalleryFile implements Comparable<GalleryFile> {
         this.decryptedCacheUri = null;
         this.lastModified = file.getLastModified();
         this.isDirectory = false;
-        this.fileType = FileType.fromMimeType(file.getMimeType());
+        this.fileType = FileType.fromFilename(encryptedName);
         this.size = file.getSize();
         this.isAllFolder = false;
     }

--- a/app/src/main/java/se/arctosoft/vault/encryption/Encryption.java
+++ b/app/src/main/java/se/arctosoft/vault/encryption/Encryption.java
@@ -86,8 +86,8 @@ public class Encryption {
         }
 
         String generatedName = StringStuff.getRandomFileName();
-        DocumentFile file = directory.createFile(sourceFile.getType(), FileType.fromMimeType(sourceFile.getType()).encryptionPrefix + generatedName);
-        DocumentFile thumb = directory.createFile(sourceFile.getType(), PREFIX_THUMB + generatedName);
+        DocumentFile file = directory.createFile("", FileType.fromMimeType(sourceFile.getType()).encryptionPrefix + generatedName);
+        DocumentFile thumb = directory.createFile("", PREFIX_THUMB + generatedName);
 
         if (file == null) {
             Log.e(TAG, "importFileToDirectory: could not create file from " + sourceFile.getUri());
@@ -118,7 +118,7 @@ public class Encryption {
             throw new RuntimeException("No password");
         }
 
-        DocumentFile file = directory.createFile("text/plain", Encryption.PREFIX_NOTE_FILE + fileNameWithoutPrefix);
+        DocumentFile file = directory.createFile("", Encryption.PREFIX_NOTE_FILE + fileNameWithoutPrefix);
 
         try {
             createFile(context, note, file, tempPassword, fileNameWithoutPrefix);

--- a/app/src/main/res/layout/adapter_gallery_viewpager_item.xml
+++ b/app/src/main/res/layout/adapter_gallery_viewpager_item.xml
@@ -12,11 +12,22 @@
 
     <TextView
         android:id="@+id/txtName"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="4dp"
         android:layout_marginEnd="4dp"
         android:textSize="12sp"
+        app:layout_constraintEnd_toStartOf="@id/imgFullscreen"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <se.arctosoft.vault.views.PressableImageView
+        android:id="@+id/imgFullscreen"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:src="@drawable/ic_round_fullscreen_24"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <se.arctosoft.vault.views.PressableConstraintLayout

--- a/app/src/main/res/layout/adapter_gallery_viewpager_item_video.xml
+++ b/app/src/main/res/layout/adapter_gallery_viewpager_item_video.xml
@@ -34,12 +34,4 @@
 
     </RelativeLayout>
 
-    <se.arctosoft.vault.views.PressableImageView
-        android:id="@+id/imgFullscreen"
-        android:layout_width="32dp"
-        android:layout_height="32dp"
-        android:src="@drawable/ic_round_fullscreen_24"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/adapter_import_list_item.xml
+++ b/app/src/main/res/layout/adapter_import_list_item.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Valv-Android
+  ~ Copyright (C) 2023 Arctosoft AB
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see https://www.gnu.org/licenses/.
+  -->
+
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/text"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:ellipsize="marquee"
+    android:padding="16dp" />

--- a/app/src/main/res/layout/dialog_import.xml
+++ b/app/src/main/res/layout/dialog_import.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Valv-Android
+  ~ Copyright (C) 2023 Arctosoft AB
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see https://www.gnu.org/licenses/.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="12dp"
+    android:paddingVertical="8dp">
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/checkbox" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,10 @@
     <string name="dialog_import_to_title">Destination</string>
     <string name="dialog_import_to_button_neutral">Add new</string>
     <string name="dialog_edit_included_title">Select folders to remove</string>
+    <plurals name="dialog_import_to_delete_original">
+        <item quantity="one">Delete the original file after importing</item>
+        <item quantity="other">Delete the original files after importing</item>
+    </plurals>
     <plurals name="edit_included_removed">
         <item quantity="one">Removed %1$d folder</item>
         <item quantity="other">Removed %1$d folders</item>

--- a/fastlane/metadata/android/en-US/changelogs/23.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23.txt
@@ -1,0 +1,4 @@
+* Encrypted files no longer have a file extension (new files only, you can safely remove the extension for all previously encrypted files)
+* Added an option to delete the original file after importing
+* The file size is now shown when viewing a file
+* Fixed long filenames appearing behind the fullscreen button on videos

--- a/fastlane/metadata/android/sv-SE/changelogs/23.txt
+++ b/fastlane/metadata/android/sv-SE/changelogs/23.txt
@@ -1,0 +1,4 @@
+* Krypterade filer har inte längre sitt ursprungliga filtillägg
+* Lade till ett alternativ för att ta bort originalfilen efter import
+* Filstorleken syns nu vid filnamnet
+* Långa filnamn visas inte längre bakom helskärmsknappen för videor


### PR DESCRIPTION
- Encrypted files no longer have a file extension (new files only, you can safely remove the extension for all previously encrypted files)
- Added an option to delete the original file after importing
- The file size is now shown when viewing a file
- Fixed long filenames appearing behind the fullscreen button on videos

Closes #23 #24 