### PR TITLE
Filenames, sharing, encoding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,8 +53,8 @@ dependencies {
     implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.security:security-crypto:1.0.0'
-    implementation 'androidx.media3:media3-exoplayer:1.3.0'
-    implementation 'androidx.media3:media3-ui:1.3.0'
+    implementation 'androidx.media3:media3-exoplayer:1.3.1'
+    implementation 'androidx.media3:media3-ui:1.3.1'
 
     implementation 'com.github.bumptech.glide:glide:4.15.1'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.15.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "se.arctosoft.vault"
         minSdk 28
         targetSdk 34
-        versionCode 25
-        versionName "1.8.1"
+        versionCode 26
+        versionName "1.8.2"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/se/arctosoft/vault/GalleryActivity.java
+++ b/app/src/main/java/se/arctosoft/vault/GalleryActivity.java
@@ -144,7 +144,7 @@ public class GalleryActivity extends AppCompatActivity {
     }
 
     private void handleSendSingle(Intent intent) {
-        Uri uri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
+        Uri uri = intent.getParcelableExtra(Intent.EXTRA_STREAM);
         if (uri != null) {
             List<Uri> list = new ArrayList<>(1);
             list.add(uri);

--- a/app/src/main/java/se/arctosoft/vault/GalleryDirectoryActivity.java
+++ b/app/src/main/java/se/arctosoft/vault/GalleryDirectoryActivity.java
@@ -236,10 +236,11 @@ public class GalleryDirectoryActivity extends AppCompatActivity {
                 }
                 Collections.sort(positionsDeleted);
                 runOnUiThread(() -> {
-                    for (int i = positionsDeleted.size() - 1; i >= 0; i--) {
-                        viewModel.getGalleryFiles().remove(i);
-                        galleryGridAdapter.notifyItemRemoved(i);
-                        galleryPagerAdapter.notifyItemRemoved(i);
+                    while (!positionsDeleted.isEmpty()) {
+                        int pos = positionsDeleted.remove(positionsDeleted.size() - 1);
+                        viewModel.getGalleryFiles().remove(pos);
+                        galleryGridAdapter.notifyItemRemoved(pos);
+                        galleryPagerAdapter.notifyItemRemoved(pos);
                     }
                     galleryGridAdapter.onSelectionModeChanged(false);
                     setLoading(false);

--- a/app/src/main/java/se/arctosoft/vault/adapters/GalleryPagerAdapter.java
+++ b/app/src/main/java/se/arctosoft/vault/adapters/GalleryPagerAdapter.java
@@ -302,7 +302,7 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
             ((GalleryPagerViewHolder.GalleryPagerGifViewHolder) holder).binding.gifImageView.setOnClickListener(v -> onItemPressed(context));
         }
         if (galleryFile.getDecryptedCacheUri() == null) {
-            new Thread(() -> Encryption.decryptToCache(context, galleryFile.getUri(), FileStuff.getExtension(galleryFile.getName()), Settings.getInstance(context).getTempPassword(), new Encryption.IOnUriResult() {
+            new Thread(() -> Encryption.decryptToCache(context, galleryFile.getUri(), FileStuff.getExtensionOrDefault(galleryFile), Settings.getInstance(context).getTempPassword(), new Encryption.IOnUriResult() {
                 @Override
                 public void onUriResult(Uri outputUri) {
                     galleryFile.setDecryptedCacheUri(outputUri);
@@ -439,7 +439,7 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
             shareOrOpenWith(context, galleryFile.getDecryptedCacheUri(), open);
         } else {
             Toaster.getInstance(context).showShort(context.getString(R.string.gallery_share_decrypting));
-            Encryption.decryptToCache(context, galleryFile.getUri(), FileStuff.getExtension(galleryFile.getName()), Settings.getInstance(context).getTempPassword(), new Encryption.IOnUriResult() {
+            Encryption.decryptToCache(context, galleryFile.getUri(), FileStuff.getExtensionOrDefault(galleryFile), Settings.getInstance(context).getTempPassword(), new Encryption.IOnUriResult() {
                 @Override
                 public void onUriResult(Uri outputUri) {
                     galleryFile.setDecryptedCacheUri(outputUri);
@@ -551,7 +551,7 @@ public class GalleryPagerAdapter extends RecyclerView.Adapter<GalleryPagerViewHo
             } else {
                 holder.parentBinding.noteLayout.setVisibility(View.VISIBLE);
                 holder.parentBinding.note.setText(context.getString(R.string.gallery_loading_note));
-                Encryption.decryptToCache(context, galleryFile.getNoteUri(), FileStuff.getExtension(galleryFile.getName()), settings.getTempPassword(), new Encryption.IOnUriResult() {
+                Encryption.decryptToCache(context, galleryFile.getNoteUri(), FileStuff.getExtensionOrDefault(galleryFile), settings.getTempPassword(), new Encryption.IOnUriResult() {
                     @Override
                     public void onUriResult(Uri outputUri) { // decrypted, now read it
                         try {

--- a/app/src/main/java/se/arctosoft/vault/data/FileType.java
+++ b/app/src/main/java/se/arctosoft/vault/data/FileType.java
@@ -26,17 +26,18 @@ import androidx.annotation.Nullable;
 import se.arctosoft.vault.encryption.Encryption;
 
 public enum FileType {
-    DIRECTORY(0, null),
-    IMAGE(1, Encryption.PREFIX_IMAGE_FILE),
-    GIF(2, Encryption.PREFIX_GIF_FILE),
-    VIDEO(3, Encryption.PREFIX_VIDEO_FILE);
+    DIRECTORY(0, null, null),
+    IMAGE(1, Encryption.PREFIX_IMAGE_FILE, ".jpg"),
+    GIF(2, Encryption.PREFIX_GIF_FILE, ".gif"),
+    VIDEO(3, Encryption.PREFIX_VIDEO_FILE, ".mp4");
 
     public final int i;
-    public final String encryptionPrefix;
+    public final String encryptionPrefix, extension;
 
-    FileType(int i, String encryptionPrefix) {
+    FileType(int i, String encryptionPrefix, String extension) {
         this.i = i;
         this.encryptionPrefix = encryptionPrefix;
+        this.extension = extension;
     }
 
     public static FileType fromFilename(@NonNull String name) {

--- a/app/src/main/java/se/arctosoft/vault/encryption/Encryption.java
+++ b/app/src/main/java/se/arctosoft/vault/encryption/Encryption.java
@@ -43,6 +43,7 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.security.spec.KeySpec;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
@@ -268,7 +269,8 @@ public class Encryption {
                 throw new InvalidPasswordException("Invalid password");
             }
         }
-        StringBuilder sb = new StringBuilder();
+        ArrayList<Byte> bytes = new ArrayList<>();
+
         if (cipherInputStream.read() == 0x0A) {
             int count = 0;
             byte[] read = new byte[1];
@@ -276,7 +278,7 @@ public class Encryption {
                 if (read[0] == 0x0A) {
                     break;
                 }
-                sb.append(new String(read));
+                bytes.add(read[0]);
                 if (++count > 300) {
                     throw new IOException("Not valid file");
                 }
@@ -284,7 +286,11 @@ public class Encryption {
         } else {
             throw new IOException("Not valid file");
         }
-        return new Streams(cipherInputStream, secretKey, sb.toString());
+        byte[] arr = new byte[bytes.size()];
+        for (int i = 0; i < bytes.size(); i++) {
+            arr[i] = bytes.get(i);
+        }
+        return new Streams(cipherInputStream, secretKey, new String(arr, StandardCharsets.UTF_8));
     }
 
     private static Streams getCipherOutputStream(FragmentActivity context, Uri input, DocumentFile outputFile, char[] password, boolean isThumb, String sourceFileName) throws GeneralSecurityException, IOException {
@@ -310,7 +316,7 @@ public class Encryption {
         if (isThumb) {
             cipherOutputStream.write(checkBytes);
         }
-        cipherOutputStream.write(("\n" + sourceFileName + "\n").getBytes());
+        cipherOutputStream.write(("\n" + sourceFileName + "\n").getBytes(StandardCharsets.UTF_8));
         return new Streams(inputStream, cipherOutputStream, secretKey);
     }
 
@@ -332,7 +338,7 @@ public class Encryption {
         writeSaltAndIV(false, salt, ivBytes, null, fos);
         fos.flush();
         CipherOutputStream cipherOutputStream = new CipherOutputStream(fos, cipher);
-        cipherOutputStream.write(("\n" + sourceFileName + "\n").getBytes());
+        cipherOutputStream.write(("\n" + sourceFileName + "\n").getBytes(StandardCharsets.UTF_8));
         return new Streams(input, cipherOutputStream, secretKey);
     }
 

--- a/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
@@ -100,7 +100,7 @@ public class FileStuff {
 
         for (CursorFile file : documentFiles) {
             if (file.isDirectory()) {
-                galleryFiles.add(GalleryFile.asDirectory(file, null)); // TODO fix later
+                galleryFiles.add(GalleryFile.asDirectory(file, null));
                 continue;
             }
             file.setNameWithoutPrefix(FileStuff.getNameWithoutPrefix(file.getName()));
@@ -186,14 +186,12 @@ public class FileStuff {
     public static List<DocumentFile> getDocumentsFromDirectoryResult(Context context, @NonNull Intent data) {
         ClipData clipData = data.getClipData();
         List<Uri> uris = FileStuff.uriListFromClipData(clipData);
-        //Log.e(TAG, "getDocumentsFromDirectoryResult: got " + uris.size());
         if (uris.isEmpty()) {
             Uri dataUri = data.getData();
             if (dataUri != null) {
                 uris.add(dataUri);
             }
         }
-        //Log.e(TAG, "getDocumentsFromDirectoryResult: got " + uris.size());
         List<DocumentFile> documentFiles = new ArrayList<>();
         for (Uri uri : uris) {
             DocumentFile pickedFile = DocumentFile.fromSingleUri(context, uri);
@@ -257,5 +255,14 @@ public class FileStuff {
         } catch (Exception ignored) {
         }
         return null;
+    }
+
+    @Nullable
+    public static String getExtensionOrDefault(GalleryFile file) {
+        String extension = getExtension(file.getName());
+        if (extension != null) {
+            return extension;
+        }
+        return file.getFileType().extension;
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.3.1' apply false
-    id 'com.android.library' version '8.3.1' apply false
+    id 'com.android.application' version '8.3.2' apply false
+    id 'com.android.library' version '8.3.2' apply false
     id 'com.mikepenz.aboutlibraries.plugin' version '10.8.3' apply false
 }
 

--- a/fastlane/metadata/android/en-US/changelogs/26.txt
+++ b/fastlane/metadata/android/en-US/changelogs/26.txt
@@ -1,0 +1,3 @@
+* Fixed a bug where deleting a file in the grid always removed the first file in the grid
+* Fixed files having the wrong extension when sharing/opening with another app
+* Filenames are now UTF-8 encoded. This fixes question marks in some filenames and exported files

--- a/fastlane/metadata/android/sv-SE/changelogs/26.txt
+++ b/fastlane/metadata/android/sv-SE/changelogs/26.txt
@@ -1,0 +1,3 @@
+* Fixade en bugg där radering av en fil i rutnätet alltid tog bort den första filen i rutnätet
+* Fix för att filer har fel filtillägg när de delas/öppnas med en annan app
+* Filnamnen är nu UTF-8 kodade. Det här åtgärdar frågetecken i vissa filnamn och exporterade filer


### PR DESCRIPTION
* Fixed a bug where deleting a file in the grid always removed the first file in the grid. 
* Fixed files having the wrong extension when sharing/opening with another app. 
* Filenames are now UTF-8 encoded. This fixes question marks in some filenames and exported files. 

Closes #70 
Closes #69 
Closes #67 