### PR TITLE
v2.2.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "se.arctosoft.vault"
         minSdk = 28
         targetSdk = 35
-        versionCode = 36
-        versionName = "2.2.1"
+        versionCode = 37
+        versionName = "2.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/se/arctosoft/vault/DirectoryAllFragment.java
+++ b/app/src/main/java/se/arctosoft/vault/DirectoryAllFragment.java
@@ -130,7 +130,7 @@ public class DirectoryAllFragment extends DirectoryBaseFragment {
             long start = System.currentTimeMillis();
             List<GalleryFile> filesToSearch = new ArrayList<>();
             for (Uri uri : uriFiles) {
-                List<GalleryFile> filesInFolder = FileStuff.getFilesInFolder(activity, uri);
+                List<GalleryFile> filesInFolder = FileStuff.getFilesInFolder(activity, uri, true);
                 for (GalleryFile foundFile : filesInFolder) {
                     if (foundFile.isDirectory()) {
                         Log.e(TAG, "findAllFiles: found " + foundFile.getNameWithPath());
@@ -236,7 +236,7 @@ public class DirectoryAllFragment extends DirectoryBaseFragment {
             return files;
         }
         incrementFolders(1);
-        List<GalleryFile> filesInFolder = FileStuff.getFilesInFolder(activity, uri);
+        List<GalleryFile> filesInFolder = FileStuff.getFilesInFolder(activity, uri, true);
         for (GalleryFile galleryFile : filesInFolder) {
             if (!isSafe()) {
                 return files;

--- a/app/src/main/java/se/arctosoft/vault/DirectoryBaseFragment.java
+++ b/app/src/main/java/se/arctosoft/vault/DirectoryBaseFragment.java
@@ -325,7 +325,7 @@ public abstract class DirectoryBaseFragment extends Fragment implements MenuProv
                 Log.e(TAG, "findFilesIn: not safe, return");
                 return;
             }
-            List<GalleryFile> galleryFiles = FileStuff.getFilesInFolder(activity, directoryUri);
+            List<GalleryFile> galleryFiles = FileStuff.getFilesInFolder(activity, directoryUri, true);
 
             activity.runOnUiThread(() -> {
                 setLoading(false);

--- a/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
@@ -307,7 +307,7 @@ public class GalleryFile implements Comparable<GalleryFile> {
             return;
         }
         new Thread(() -> {
-            List<GalleryFile> galleryFiles = FileStuff.getFilesInFolder(context, fileUri);
+            List<GalleryFile> galleryFiles = FileStuff.getFilesInFolder(context, fileUri, false);
             this.fileCount = 0;
             this.firstFileInDirectoryWithThumb = null;
             for (GalleryFile f : galleryFiles) {

--- a/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
+++ b/app/src/main/java/se/arctosoft/vault/data/GalleryFile.java
@@ -338,11 +338,11 @@ public class GalleryFile implements Comparable<GalleryFile> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         GalleryFile that = (GalleryFile) o;
-        return size == that.size && fileType == that.fileType && Objects.equals(originalName, that.originalName);
+        return size == that.size && fileType == that.fileType && Objects.equals(encryptedName, that.encryptedName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(size, fileType, originalName);
+        return Objects.hash(size, fileType, encryptedName);
     }
 }

--- a/app/src/main/java/se/arctosoft/vault/subsampling/MySubsamplingScaleImageView.java
+++ b/app/src/main/java/se/arctosoft/vault/subsampling/MySubsamplingScaleImageView.java
@@ -1945,7 +1945,7 @@ public class MySubsamplingScaleImageView extends View {
                 Log.w(TAG, "Could not get EXIF orientation of image");
             }
         }*/
-        return orientation;
+        return orientation == -1 ? ORIENTATION_0 : orientation;
     }
 
     private void execute(AsyncTask<Void, Void, ?> asyncTask) {

--- a/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
+++ b/app/src/main/java/se/arctosoft/vault/utils/FileStuff.java
@@ -56,7 +56,7 @@ public class FileStuff {
     private static final String TAG = "FileStuff";
 
     @NonNull
-    public static List<GalleryFile> getFilesInFolder(Context context, Uri pickedDir) {
+    public static List<GalleryFile> getFilesInFolder(Context context, Uri pickedDir, boolean checkDecryptable) {
         //Log.e(TAG, "getFilesInFolder: " + pickedDir);
         Uri realUri = DocumentsContract.buildChildDocumentsUriUsingTree(pickedDir, DocumentsContract.getDocumentId(pickedDir));
         List<CursorFile> files = new ArrayList<>();
@@ -86,7 +86,7 @@ public class FileStuff {
         List<GalleryFile> encryptedFilesInFolder = getEncryptedFilesInFolder(files, context);
         Collections.sort(encryptedFilesInFolder);
 
-        if (Settings.getInstance(context).displayDecryptableFilesOnly()) {
+        if (checkDecryptable && Settings.getInstance(context).displayDecryptableFilesOnly()) {
             long start = System.currentTimeMillis();
             List<GalleryFile> readableFiles = new ArrayList<>();
             final Queue<GalleryFile> fileQueue = new ArrayDeque<>(encryptedFilesInFolder);

--- a/fastlane/metadata/android/en-US/changelogs/37.txt
+++ b/fastlane/metadata/android/en-US/changelogs/37.txt
@@ -1,0 +1,7 @@
+* The folder preview and file count now update after modifying the folder contents
+* Added a setting to hide all files encrypted using a different password
+* Added a setting to go to the password screen when locking instead of exiting
+* Fixed duplicate files in the All folder
+* Fixed images being displayed in the wrong orientation
+* Fixed missing fast scroll bar
+* Fixed a crash when scrolling fast in the grid

--- a/fastlane/metadata/android/sv-SE/changelogs/37.txt
+++ b/fastlane/metadata/android/sv-SE/changelogs/37.txt
@@ -1,0 +1,7 @@
+* Mappförhandsgranskningen och filantalet uppdateras nu efter att mappinnehållet har ändrats
+* Lade till en inställning för att dölja alla filer krypterade med ett annat lösenord
+* Lade till en inställning för att gå till lösenordsskärmen när du låser istället för att avsluta appen
+* Fixade dubbletter av filer i Alla-mappen
+* Fixade bilder som visades i fel orientering
+* Fixade saknad snabbrullning
+* Fixade en krasch när du scrollar snabbt i rutnätet


### PR DESCRIPTION
- Fixed large images not being displayed
- Fixed selecting a folder selected all folders. Closes #120 
- The app no longer reads all files in subfolders when the "Display only decryptable files" setting is enabled for faster loading